### PR TITLE
Allow periods in full names

### DIFF
--- a/client/app-more/util/FullNameInput.more.ts
+++ b/client/app-more/util/FullNameInput.more.ts
@@ -23,8 +23,8 @@
 
 const r = ReactDOMFactories;
 
-// Allow '-'. '@' is checked elsewhere.
-const BadSymbolsRegex = /[!$%^&*()+|~=`{}\[\]:";<>?,.\/#]/;
+// Allow '-' and '.'. '@' is checked elsewhere.
+const BadSymbolsRegex = /[!$%^&*()+|~=`{}\[\]:";<>?,\/#]/;
 
 
 export var FullNameInput = createClassAndFactory({


### PR DESCRIPTION
The commenting system currently prohibits periods in name values, but periods are fairly common in names (e.g., F. Scott Fitzgerald, C.S. Lewis, John F. Kennedy).

This change adjusts the regex for illegal name characters by removing '.' as an illegal character in full names.

I, Michael Lynch \<git@mtlynch.io\>, agree to the Contributor License Agreement, docs/CLA-v2.txt.