### PR TITLE
Seed sites3.next_page_id after a full site import (fixes TyE306KSH4)

### DIFF
--- a/appsv/model/src/main/scala/com/debiki/core/SiteTransaction.scala
+++ b/appsv/model/src/main/scala/com/debiki/core/SiteTransaction.scala
@@ -352,6 +352,11 @@ trait SiteTransaction {   RENAME // to SiteTx — already started with a type Si
 
   def nextPageId(): PageId
 
+  /** Raises sites3.next_page_id to at least `toAtLeast`, so that nextPageId() won't
+    * hand out ids that collide with pages inserted with explicit ids during a full
+    * site import. Never lowers the counter (uses GREATEST). [TyT_NEXTPAGEID] */
+  def bumpNextPageId(toAtLeast: Int): Unit
+
   def loadAllPageMetas(limit: Option[Int] = None): immutable.Seq[PageMeta]
   def loadPageMeta(pageId: PageId): Option[PageMeta]
   def loadPageMetasAsMap(pageIds: Iterable[PageId], anySiteId: Option[SiteId] = None)

--- a/appsv/rdb/src/main/scala/com/debiki/dao/rdb/RdbSiteTransaction.scala
+++ b/appsv/rdb/src/main/scala/com/debiki/dao/rdb/RdbSiteTransaction.scala
@@ -473,6 +473,18 @@ class RdbSiteTransaction(var siteId: SiteId, val daoFactory: RdbDaoFactory, val 
   }
 
 
+  def bumpNextPageId(toAtLeast: Int): Unit = {
+    // GREATEST => idempotent, and never lowers the counter (e.g. if the dump's
+    // declared next_page_id, or pages inserted later, already pushed it higher).
+    dieIf(toAtLeast < 1, "TyE5PAGEID0", s"toAtLeast = $toAtLeast, must be >= 1")
+    val statement = """
+      update sites3
+      set next_page_id = greatest(next_page_id, ?)
+      where id = ?"""
+    runUpdateExactlyOneRow(statement, List(toAtLeast.asAnyRef, siteId.asAnyRef))
+  }
+
+
   def loadAllPageMetas(limit: Option[Int] = None): immutable.Seq[PageMeta] =
     loadPageMetaImpl(pageIds = Nil, all = true, limit = limit).values.to(immutable.Seq)
 

--- a/appsv/server/talkyard/server/sitepatch/SitePatcher.scala
+++ b/appsv/server/talkyard/server/sitepatch/SitePatcher.scala
@@ -1458,6 +1458,24 @@ case class SitePatcher(globals: debiki.Globals) {
         tx.insertPageMetaMarkSectionPageStale(pageMeta, isImporting = true)(IfBadAbortReq)
       }
 
+      // The pages above were inserted with their explicit ids from the dump, but
+      // createAdditionalSite() left sites3.next_page_id at its default (1). Unlike
+      // post & category ids (which use max(id) + 1 and self-heal), page ids come from
+      // that stored counter — so seed it past the highest imported page id. Otherwise
+      // the next new page would start at id 1, collide with the imported pages, and
+      // nextPageId() would give up after 100 laps [TyE306KSH4]. Page ids are Strings;
+      // only numeric ones come from the counter, so ignore special/non-numeric ids
+      // (e.g. `_stylesheet`). Honour the dump's declared next_page_id too, if higher.
+      // Compute in Long and reject clearly at the Int page-id ceiling, so we never
+      // silently overflow (a numeric page id could be exactly Int.MaxValue).
+      val maxNumericPageId: Int =
+        siteData.pages.iterator.flatMap(_.pageId.toIntOption).maxOption.getOrElse(0)
+      val nextPageIdSeed: Long =
+        math.max(maxNumericPageId.toLong + 1, siteToSave.nextPageId.toLong)
+      throwBadRequestIf(nextPageIdSeed > Int.MaxValue, "TyEIMPPAGEIDMAX",
+            s"Cannot import: next page id would exceed the max page id, $nextPageIdSeed")
+      tx.bumpNextPageId(nextPageIdSeed.toInt)
+
       siteData.pagePaths foreach { path =>
         try {
           tx.insertPagePath(path)

--- a/tests/app/talkyard/server/sitepatch/DumpMaker.scala
+++ b/tests/app/talkyard/server/sitepatch/DumpMaker.scala
@@ -41,6 +41,15 @@ trait DumpMaker {
     importer.upsertIntoExistingSite(siteDao.siteId, completePatch, browserIdData)
   }
 
+  /** Full-site import (restore), i.e. create a whole new site from a dump — the code
+    * path that inserts pages with their explicit ids. Pass anySiteToOverwrite to reuse
+    * (and delete) an existing site's id + hostname. [TyT_NEXTPAGEID] */
+  def importCreateSite(siteData: SitePatch, anySiteToOverwrite: Option[Site] = None): Site = {
+    val importer = SitePatcher(globals)
+    importer.importCreateSite(
+          siteData, browserIdData, anySiteToOverwrite = anySiteToOverwrite, isTest = true)
+  }
+
 
 
   val FirstGuestTempImpId: UserId = - LowestTempImpId - 1

--- a/tests/app/talkyard/server/sitepatch/SitePatcherAppSpec.scala
+++ b/tests/app/talkyard/server/sitepatch/SitePatcherAppSpec.scala
@@ -764,6 +764,58 @@ class SitePatcherAppSpec extends DaoAppSuite // (disableScripts = false)  // TyT
 
 
 
+  // Regression test for the stale next_page_id import bug [TyT_NEXTPAGEID] [TyE306KSH4]:
+  // a full site import inserts pages with their explicit ids, but must ALSO seed
+  // sites3.next_page_id — otherwise the next new page starts at id 1, collides with the
+  // imported pages, and nextPageId() gives up after 100 laps.
+  "SitePatcher seeds next_page_id after a full import" - {
+    var seedSite: Site = null
+    var seedDao: SiteDao = null
+    var staleDump: SitePatch = null
+    var maxNumericPageId: Int = -1
+
+    "create a seed site with a few pages, so the max page id is > 1" in {
+      val (site, dao) = createSite("nextpageid-seed-2958471")
+      seedSite = site
+      seedDao = dao
+      for (i <- 1 to 3) {
+        createPage(PageType.Discussion,
+              titleTextAndHtml = textAndHtmlMaker.testTitle(s"Title $i"),
+              bodyTextAndHtml = textAndHtmlMaker.testBody(s"Body $i"),
+              authorId = SystemUserId, browserIdData = browserIdData, dao = seedDao)
+      }
+    }
+
+    "load its dump, then force next_page_id back to 1 (reproduce the stale counter)" in {
+      val dump = SitePatchMaker(context = context).loadSiteDump(seedSite.id)
+      maxNumericPageId = dump.pages.flatMap(_.pageId.toIntOption).max
+      maxNumericPageId must be > 1
+      // loadSiteDump omits settings, but importCreateSite requires them (TyE5KRYTG02):
+      staleDump = dump.copy(
+            site = Some(dump.theSite.copy(nextPageId = 1)),
+            settings = Some(SettingsToSave(orgFullName = Some(Some("Test Org")))),
+            isTestSiteOkDelete = true)
+    }
+
+    "importing it (overwriting the seed) seeds next_page_id past the max page id" in {
+      importCreateSite(staleDump, anySiteToOverwrite = Some(seedSite))
+      // THE REGRESSION CLINCHER: on unpatched code this reads 1 (createAdditionalSite's
+      // default, never advanced) and FAILS; with the fix it is maxNumericPageId + 1.
+      val reDump = SitePatchMaker(context = context).loadSiteDump(seedSite.id)
+      reDump.theSite.nextPageId mustBe (maxNumericPageId + 1)
+    }
+
+    "and a new page can then be created without dying with TyE306KSH4" in {
+      val dao = globals.siteDao(seedSite.id)
+      val newPageId = createPage(PageType.Discussion,
+            titleTextAndHtml = textAndHtmlMaker.testTitle("After import"),
+            bodyTextAndHtml = textAndHtmlMaker.testBody("Body"),
+            authorId = SystemUserId, browserIdData = browserIdData, dao = dao)
+      newPageId.toInt must be >= (maxNumericPageId + 1)
+    }
+  }
+
+
   "SitePatcher can also" - {
 
     "Import new pages and replies, all posts approved" - {


### PR DESCRIPTION
## The bug (`TyE306KSH4`)

After a full site import/restore, `sites3.next_page_id` is left at its default (`1`) instead of being advanced past the imported pages' ids. Page ids come from that stored counter (`inc_next_page_id`), unlike post & category ids which self-heal via `max(id)+1`. So the next new page starts at id 1, collides with the just-imported pages, and `nextPageId()` gives up after 100 laps → `TyE306KSH4`.

**Real-world repro:** a self-hosted site imported with pages up to id 145 while `next_page_id` stayed at `1` → creating any new topic failed.

## The fix

In `importCreateSite()`, after inserting the pages, seed `next_page_id` to `max(highest numeric imported page id + 1, dump's declared next_page_id)` via a new `bumpNextPageId()` transaction method:

```
update sites3 set next_page_id = greatest(next_page_id, ?) where id = ?
```

`GREATEST` ⇒ idempotent, never lowers the counter. Non-numeric/special page ids and ids larger than `Int` are ignored (`toIntOption`), so it can't overflow.

**This changes only the id handed to _new_ pages created after the import.** Existing pages keep their ids, so links/backlinks to them are unaffected. The `upsertIntoExistingSite` path already advances the counter via `nextPageId()` and is left untouched.

## Tests

- **App-level regression test** (`SitePatcherAppSpec` + a `DumpMaker.importCreateSite` helper): imports a dump with a stale counter, asserts `next_page_id` is seeded past the max page id, and creates a new page without `TyE306KSH4`. Verified it **fails on unpatched code** (`1 was not equal to 4`) and passes with the fix.
- **Full wdio7 e2e, baseline vs. change**, run locally (139 specs, serial). Methodology + results in the working log linked below.

## Heads-up: 3 e2e specs need their expected page ids updated (not a fix bug)

With the fix, 3 specs regress: `api-upsert-posts.2br.d`, `alias-anons-basic-perm.2br.f`, `alias-anons-basic-temp.2br.f`. The exact cause:

The e2e site-builder assigns page ids as `opts.id + 19000` (`tests/e2e-wdio7/utils/site-builder.ts:127`), so test dumps carry pages at ids ~19002–19004 while declaring `nextPageId = 100` — internally inconsistent, i.e. exactly the stale-counter condition this fix heals. On unpatched code the counter isn't seeded, so new pages **gap-fill** the free low ids (2, 3…), which these specs hard-code (`c.SecondPageId = '2'`). With the fix, the counter is correctly seeded **past the max** (→ 19005), so new pages get high ids and the hard-coded assertions fail.

Only pages created _after_ import are affected — existing pages/links are not, and real-world sites (contiguous ids) behave identically to before. These 3 specs — or the builder's `+19000`/`nextPageId` inconsistency — just need their expected ids updated. I left them untouched since they encode intent about your test harness; happy to follow up whichever way you prefer.

## Already-imported sites (one-time heal)

The fix prevents new damage; it doesn't retro-heal sites imported before it (like the repro). A safe, idempotent one-liner (no-op on healthy sites):

```sql
update sites3 s set next_page_id = greatest(s.next_page_id, coalesce((
  select least(max((p.page_id)::bigint) + 1, 2147483647)
  from pages3 p
  where p.site_id = s.id and p.page_id ~ '^[0-9]+$' and length(p.page_id) <= 9), 1));
```

Deliberately **not** shipped as a migration — a bulk row-update across all tenants at startup felt like your call, not something to run unasked.

## Full working log & investigation

The complete diagnosis, the app-test proof, and the full e2e testing (including a fairly deep investigation into *why* the fix changes those 3 specs) are documented here, if useful:
https://forum.ivanthegeek.com/-189

Take it as-is, modify freely, or just use it as a pointer — whatever's most helpful. 🙂

---
*Authored by Ivan (IvanTheGeek); the fix + analysis were done with AI assistance (Claude), as noted in the commit and the working log — flagging for transparency.*
