### PR TITLE
Fix the pnpm-in-container path: pnpm missing from the nodejs image, s/yarn drops its args

### DIFF
--- a/images/nodejs/Dockerfile
+++ b/images/nodejs/Dockerfile
@@ -53,6 +53,12 @@ RUN \
 RUN cd /usr/local/bin/ && \
     ln -s /opt/talkyard/server/node_modules/.bin/gulp ./
 
+# pnpm, so `docker compose run --rm nodejs pnpm ...` works (s/yarn, and the
+# to-talkyard Makefile target). The base image has no pnpm and Node is
+# removing bundled corepack, so install explicitly. Same major as in
+# images/builder/Dockerfile.
+RUN npm install -g pnpm@10
+
 WORKDIR /opt/talkyard/server/
 
 COPY entrypoint.sh /docker-entrypoint.sh

--- a/s/yarn
+++ b/s/yarn
@@ -2,6 +2,13 @@
 
 # Gah! 'yarn' and 'yarn install'  nowadays (or did it always?) deletes ./node_modules/,
 # see:  [yarn_deletes_mods_dir]  in s/tyd.ts.
-# 
-sudo s/d run --rm nodejs pnpm
+#
+# Runs pnpm in the nodejs container (the repo is mounted there), so the host
+# doesn't need Nodejs or pnpm installed. With no arguments, runs 'pnpm install'
+# — like bare 'yarn' used to do — which is what 'make node_modules' expects.
 
+if [ $# -eq 0 ]; then
+  set -- install
+fi
+
+sudo s/d run --rm nodejs pnpm "$@"


### PR DESCRIPTION
Two small pnpm-migration leftovers that break the pnpm-in-container path:

1. **The nodejs image has no pnpm.** `node:24.14.0-trixie-slim` doesn't bundle it (and Nodejs is phasing out bundled corepack), so anything doing `docker compose run --rm nodejs pnpm ...` fails with `pnpm: command not found`. That's `s/yarn`, and therefore the `make node_modules` fallback — which a fresh clone hits if the vendored `node_modules` submodule isn't initialized yet. Fix: install pnpm explicitly in `images/nodejs/Dockerfile`.

2. **`s/yarn` dropped its arguments.** It ran bare `pnpm` (no `"$@"`), which just prints pnpm's usage and installs nothing. Now it passes arguments through, and with no arguments runs `pnpm install` (like bare `yarn` used to), which is what `make node_modules` expects.

Verified after the fix: `docker compose run --rm nodejs pnpm --version` → 10.34.5, and `s/yarn --version` works.

Deliberately **not** touched: the `to-talkyard` Makefile target that still calls yarn — you mentioned on [Ivan's forum](https://forum.ivanthegeek.com/-189/) that a fix for that is already on a private branch, so this PR stays out of its way. (Found while making the build run with only Docker on the host; more on that experiment soon in the contributor-friendly thread.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)