### PR TITLE
Fix prod app image build: sqlx-cli 0.9.0 needs rustc 1.94, stage pins rust 1.93

### DIFF
--- a/images/app/Dockerfile.prod
+++ b/images/app/Dockerfile.prod
@@ -5,9 +5,13 @@
 # (Rust has only Debian based images, Temurin (for Java) has only Ubuntu
 # based images.)
 #
-FROM rust:1.93.0-trixie AS rust_img
+# Rust >= 1.94 needed: unpinned 'cargo install sqlx-cli' started resolving to
+# sqlx-cli 0.9.0 (needs rustc >= 1.94) in July 2026, breaking this build on
+# rust 1.93. Same rust version as Dockerfile.dev now. sqlx-cli pinned to the
+# version the published talkyard-app images ship.
+FROM rust:1.94.0-trixie AS rust_img
 
-RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres
+RUN cargo install sqlx-cli --version =0.8.6 --no-default-features --features native-tls,postgres
 
 
 # Ubuntu 24.04. See: https://hub.docker.com/_/eclipse-temurin, and ./Dockerfile.dev .


### PR DESCRIPTION
The prod app image build is currently broken: `cargo install sqlx-cli` in `images/app/Dockerfile.prod` is unpinned, and sqlx-cli 0.9.0 (published July 2026) requires rustc ≥ 1.94 — but the stage pins `rust:1.93.0-trixie`:

```
error: cannot install package `sqlx-cli 0.9.0`, it requires rustc 1.94.0 or newer,
while the currently active rustc version is 1.93.0
```

Fix:
- bump the build stage to `rust:1.94.0-trixie` (same as Dockerfile.dev), and
- **pin `sqlx-cli =0.8.6`** — the version the published talkyard-app images actually ship (checked `v1.2026.003-f220a7d9f` and `v1.2026.004-e80b4519d` via `sqlx --version`) — so image contents stay deterministic instead of tracking whatever crates.io serves next.

Verified: the rust stage builds, and a full prod app image built with this pin is file-for-file layout-identical to the published `v1.2026.003-f220a7d9f` image, with the same `sqlx-cli 0.8.6`.

Note: Dockerfile.dev installs sqlx-cli unpinned too — its rust 1.94 happens to build 0.9.0 fine today, but you may want the same `=0.8.6` pin there for dev/prod consistency (left out of this PR to keep the diff minimal).

Found during the same Docker-only-build work as #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)