### PR TITLE
e2e: add missing .mtime marker to 4 magic-time wdio7 specs

### DIFF
--- a/appsv/server/controllers/ModerationController.scala
+++ b/appsv/server/controllers/ModerationController.scala
@@ -178,7 +178,7 @@ class ModerationController @Inject()(cc: ControllerComponents, edContext: TyCont
   def acceptAllUnreviewed: Action[JsValue] = AdminPostJsonAction(maxBytes = 100) { req =>
     // Disabled by default — not well tested enough, just this:
     // Tests:  (not enough)
-    //   - modn-review-specific-user.3br.f  TyTMOD_REVW_USR.TyTMODACPTUNREV
+    //   - modn-review-specific-user.3br.f.mtime  TyTMOD_REVW_USR.TyTMODACPTUNREV
     import req.dao
     val site = dao.theSite()
     val flagName = "ffApproveUnreviewed"

--- a/docs/tests-map.txt
+++ b/docs/tests-map.txt
@@ -328,7 +328,7 @@ anons:
   _anon_e2e_to_code_review:
             - alias-anons-basic-temp.2br.f
             - alias-anons-basic-perm.2br.f
-            - alias-anons-approve-review.2br.f
+            - alias-anons-approve-review.2br.f.mtime
             - alias-anons-edit-alter.2br.f
   TESTS_MISSING, not impl:
             - alias-anons-true-mixed.2br.f
@@ -881,11 +881,11 @@ bookmarks:
   delete,
   jump to,
   access perms (move page to private cat):
-            - bookmarks-basic.2br.f  TyTBOKM_BSC
+            - bookmarks-basic.2br.f.mtime  TyTBOKM_BSC
     can't find when searching:
             - TESTS_MISSING  TyTBOKM_SRCH_0FIND
   sort order:
-            - bookmarks-basic.2br.f  TyTBOKM_BSC.TyTBOKM_ORDR
+            - bookmarks-basic.2br.f.mtime  TyTBOKM_BSC.TyTBOKM_ORDR
   recreate after deleted:
             - TESTS_MISSING
   edit text:
@@ -1499,7 +1499,7 @@ moderation,
 approve before,
 review after:
     author names:
-            -  modn-ban-spammer.2br.f  TyTMODNBANSPM.TyTMODN_AUTHRNAME
+            -  modn-ban-spammer.2br.f.mtime  TyTMODNBANSPM.TyTMODN_AUTHRNAME
     ninja edits,
     normal edits,
     late edits
@@ -1525,7 +1525,7 @@ review after:
     bad user auto-banned:
     invalidating review tasks: [2VSP5Q8]
       band & delete all:
-            - modn-ban-spammer.2br.f  TyTMODNBANSPM
+            - modn-ban-spammer.2br.f.mtime  TyTMODNBANSPM
             - modn-ban-from-disc-page.2br.f  TyTEBANFROMDISC.TyTMODN_TASKINV
       reject-delete post:
             - admin-review-invalidate-for-reply.2browsers.test.ts  TyT6KWB42A
@@ -1635,7 +1635,7 @@ review after:
     #    Memah visits reply — not found.
 
   accept unreviewed:
-            - modn-review-specific-user.3br.f  TyTMOD_REVW_USR.TyTMODACPTUNREV
+            - modn-review-specific-user.3br.f.mtime  TyTMOD_REVW_USR.TyTMODACPTUNREV
                 But TESTS_MISSING in prod builds
 
 report post,
@@ -1657,7 +1657,7 @@ spam: (4BKS0)
           - spam-basic-safe-browsing-api-blocked.2browsers.test.ts  TyTSPSAFEBRAPI
   ban spammer:
     who is a user:
-            - modn-ban-spammer.2br.f  TyTMODNBANSPM
+            - modn-ban-spammer.2br.f.mtime  TyTMODNBANSPM
             - modn-ban-from-disc-page.2br.f  TyTEBANFROMDISC
     who is a guest:
             - TESTS_MISSING  [block_post_author_e2e_test]
@@ -1884,7 +1884,7 @@ live notfs,
 live notifications -
   reply appears in 2nd browser:
             - delete-pages.2br  TyTE2EDELPG602.TyTWS702MEGR5
-            - modn-ban-spammer.2br.f  TyTMODNBANSPM.TyTWS702MEGR5
+            - modn-ban-spammer.2br.f.mtime  TyTMODNBANSPM.TyTWS702MEGR5
   attacker tries to bypass authentication:
           -  TESTS_MISSING  TyTWSAUTH
   reconnects after disconnection:

--- a/s/run-e2e-tests.sh
+++ b/s/run-e2e-tests.sh
@@ -376,7 +376,7 @@ function runAllE2eTests {
   $r s/wdio --only drafts-chat-adv-ed.2browsers $args
   $r s/wdio --only drafts-delete $args
 
-  $r s/wdio-7 --only bookmarks-basic.2br.f --cd -i $args
+  $r s/wdio-7 --only bookmarks-basic.2br.f.mtime --cd -i $args
 
   # Wip:
   # $r s/wdio-7 --only frag-action-compose-topic.2br.f.wip.ts --cd -i
@@ -579,9 +579,9 @@ function runAllE2eTests {
   # Moderation   (4862065)
   # ------------
 
-  $r s/wdio-7 --only modn-review-specific-user.3br.f --cd -i $args
+  $r s/wdio-7 --only modn-review-specific-user.3br.f.mtime --cd -i $args
 
-  $r s/wdio-7 --only modn-ban-spammer.2br.f.e2e.ts --cd -i $args
+  $r s/wdio-7 --only modn-ban-spammer.2br.f.mtime.e2e.ts --cd -i $args
 
   $r s/wdio-7 --only may-see-email-adrs.2br.d --cd -i $args
 
@@ -591,7 +591,7 @@ function runAllE2eTests {
 
   $r s/wdio-7 --only alias-anons-basic-temp.2br.f --cd -i $args
   $r s/wdio-7 --only alias-anons-basic-perm.2br.f --cd -i $args
-  $r s/wdio-7 --only alias-anons-approve-review.2br.f --cd -i $args
+  $r s/wdio-7 --only alias-anons-approve-review.2br.f.mtime --cd -i $args
   $r s/wdio-7 --only alias-anons-edit-alter.2br.f --cd -i $args
   # $r s/wdio-7 --only alias-anons-true-mixed.2br.f --cd -i $args
   # Would be good with this too, later:

--- a/tests/e2e-wdio7/specs/alias-anons-approve-review.2br.f.mtime.e2e.ts
+++ b/tests/e2e-wdio7/specs/alias-anons-approve-review.2br.f.mtime.e2e.ts
@@ -68,7 +68,7 @@ const allPostTexts = [
 let expectedNumEmails = 0;
 
 
-describe(`alias-anons-approve-review.2br.f  TyTALIANONAPRREV`, () => {
+describe(`alias-anons-approve-review.2br.f.mtime  TyTALIANONAPRREV`, () => {
 
   it(`Construct site`, async () => {
     make.setNextUserId(1020304001); // [e2e_forbidden_anon_ids]

--- a/tests/e2e-wdio7/specs/bookmarks-basic.2br.f.mtime.e2e.ts
+++ b/tests/e2e-wdio7/specs/bookmarks-basic.2br.f.mtime.e2e.ts
@@ -46,7 +46,7 @@ function linkTo(page: St | { id: St }, postNr?: Nr): St {
   return !postNr ? pageLink : pageLink + `#post-${postNr}`;
 }
 
-describe(`bookmarks-basic.2br.f  TyTBOKM_BSC`, () => {
+describe(`bookmarks-basic.2br.f.mtime  TyTBOKM_BSC`, () => {
 
   it(`Construct site`, async () => {
     const builder = buildSite();

--- a/tests/e2e-wdio7/specs/modn-ban-spammer.2br.f.mtime.e2e.ts
+++ b/tests/e2e-wdio7/specs/modn-ban-spammer.2br.f.mtime.e2e.ts
@@ -98,7 +98,7 @@ const mallorysReplyToAngryElk = `Sure, just pay to this BitCoin address, wait`;
 
 
 
-describe(`modn-ban-spammer.2br.f  TyTMODNBANSPM`, () => {
+describe(`modn-ban-spammer.2br.f.mtime  TyTMODNBANSPM`, () => {
 
   it(`Construct site`, async () => {
     const builder = buildSite();

--- a/tests/e2e-wdio7/specs/modn-review-specific-user.3br.f.mtime.e2e.ts
+++ b/tests/e2e-wdio7/specs/modn-review-specific-user.3br.f.mtime.e2e.ts
@@ -32,7 +32,7 @@ let mariasTopicUrl: St;
 
 
 
-describe(`modn-review-specific-user.3br.f  TyTMOD_REVW_USR`, () => {
+describe(`modn-review-specific-user.3br.f.mtime  TyTMOD_REVW_USR`, () => {
 
   it(`Construct site`, async () => {
     const builder = buildSite();


### PR DESCRIPTION
The tyd e2e runner decides parallel-vs-serial purely from the `.mtime` filename marker: marked specs run with `--not-parallel`, everything else is eligible for the parallel batch under `--parallel N` (`s/impl/tyd-e2e-tests.ts`, grouping around lines 273–285).

Four wdio7 specs advance the **server-global test clock** without the marker — each calls `adminArea.review.playTimePastUndo()`, i.e. `server.playTimeSeconds(c.ReviewDecisionUndoTimoutSeconds + 10)` (`ty-e2e-test-browser.ts:10293`):

- `alias-anons-approve-review.2br.f.e2e.ts`
- `bookmarks-basic.2br.f.e2e.ts`
- `modn-ban-spammer.2br.f.e2e.ts`
- `modn-review-specific-user.3br.f.e2e.ts`

Under `--parallel` they land in the parallel batch and can jump time underneath unrelated concurrent specs — expired sessions, skipped review-undo windows, skewed notification timing; scheduling-dependent flakiness. It's the failure mode the existing TODO warns about (`tyd-e2e-tests.ts:241`: *"Don't run magic time tests in parallel — they mess up the time for each other"*).

This PR just renames the four files to carry `.mtime`, and updates the references so nothing dangles:

1. the `describe()` titles (they mirror the filenames),
2. `docs/tests-map.txt` (8 lines),
3. the `--only` args in `s/run-e2e-tests.sh` — **one of them used the full filename** (`modn-ban-spammer.2br.f.e2e.ts`) and would silently have stopped matching,
4. a spec-name comment in `ModerationController.scala`.

No code changes — `git show --stat` is 4 renames (99% similarity) + 17 reference lines.

For contrast I checked the wdio6 suite too: its 25 clock-moving specs are exactly the 25 `.mtime`-named ones, zero drift (verified by grepping spec bodies for `playTime`/`pauseServerAndBrowsers` and diffing against filenames). A longer-term hardening idea: have the runner grep spec bodies for `playTime` instead of trusting filenames, so future drift can't reintroduce this.

Found while analyzing which e2e specs can run in parallel — write-up: https://forum.ivanthegeek.com/-206

🤖 Generated with [Claude Code](https://claude.com/claude-code)